### PR TITLE
fix: replace replication conflict metric name

### DIFF
--- a/ipahealthcheck_exporter.go
+++ b/ipahealthcheck_exporter.go
@@ -48,7 +48,7 @@ var (
 	)
 
 	scrapedChecks = map[string]scrapedCheck{
-		"ReplicationConflictCheck": {
+		"ReplicationCheck": {
 			scrape:      true,
 			metricsDesc: ipahealthcheckReplicationCheckDesc,
 		},


### PR DESCRIPTION
In log file, the check value is not `ReplicationConflictCheck` but `ReplicationCheck`
```
  {
    "source": "ipahealthcheck.ds.replication",
    "check": "ReplicationCheck",
...
```
